### PR TITLE
Fix ChromeDriver initialization on selenium 4.x

### DIFF
--- a/sample_config.py
+++ b/sample_config.py
@@ -152,9 +152,6 @@ class Config(object):
         until_date=None, view_messages=None, send_messages=True
     )
     CHROME_BIN = os.environ.get("CHROME_BIN", "/app/.apt/usr/bin/google-chrome")
-    CHROME_DRIVER = os.environ.get(
-        "CHROME_DRIVER", "/app/.chromedriver/bin/chromedriver"
-    )
     # for sed plugin
     GROUP_REG_SED_EX_BOT_S = os.environ.get(
         "GROUP_REG_SED_EX_BOT_S", r"(regex|moku|BananaButler_|rgx|l4mR)bot"

--- a/userbot/helpers/google_tools.py
+++ b/userbot/helpers/google_tools.py
@@ -15,6 +15,7 @@ from datetime import datetime
 
 import requests
 from selenium import webdriver
+from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.common.by import By
 
 from ..Config import Config
@@ -25,16 +26,20 @@ class chromeDriver:
     @staticmethod
     def start_driver():
         if Config.CHROME_BIN is None:
-            return None, "Need to install Google Chrome. Module Stopping."
+            return None, "Need to install Google Chrome or Chromium. Module Stopping."
         try:
-            chrome_options = webdriver.ChromeOptions()
+            chrome_options = ChromeOptions()
+            chrome_options.binary_location = Config.CHROME_BIN
             chrome_options.add_argument("--ignore-certificate-errors")
             chrome_options.add_argument("--test-type")
-            chrome_options.add_argument("--headless")
+            chrome_options.add_argument("--headless=new")
             chrome_options.add_argument("--no-sandbox")
             chrome_options.add_argument("--disable-dev-shm-usage")
-            chrome_options.binary_location = Config.CHROME_BIN
-            driver = webdriver.Chrome(chrome_options=chrome_options)
+            chrome_options.add_argument("--window-size=1920x1080")
+            chrome_options.add_argument("--disable-gpu")
+            prefs = {"download.default_directory": "./"}
+            chrome_options.add_experimental_option("prefs", prefs)
+            driver = webdriver.Chrome(options=chrome_options)
             return driver, None
         except Exception as err:
             return None, str(err)

--- a/userbot/plugins/carbon.py
+++ b/userbot/plugins/carbon.py
@@ -12,16 +12,29 @@ import os
 import random
 from urllib.parse import quote_plus
 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-
-from ..Config import Config
 from ..core.managers import edit_delete, edit_or_reply
+from ..helpers.google_tools import chromeDriver
 from . import catub, deEmojify
 
 plugin_category = "utils"
 
-CARBONLANG = "auto"
+carbon_language = "auto"
+
+
+def download_carbon(driver, url):
+    driver.get(url)
+    download_path = "./"
+    driver.command_executor._commands["send_command"] = (
+        "POST",
+        "/session/$sessionId/chromium/send_command",
+    )
+    params = {
+        "cmd": "Page.setDownloadBehavior",
+        "params": {"behavior": "allow", "downloadPath": download_path},
+    }
+    driver.execute("send_command", params)
+
+    driver.find_element("xpath", "//button[contains(text(),'Export')]").click()
 
 
 @catub.cat_cmd(
@@ -37,48 +50,25 @@ CARBONLANG = "auto"
 )
 async def carbon_api(event):
     """A Wrapper for carbon.now.sh"""
-    await event.edit("`Processing..`")
-    CARBON = "https://carbon.now.sh/?l={lang}&code={code}"
-    textx = await event.get_reply_message()
-    pcode = event.text
-    if pcode[8:]:
-        pcode = str(pcode[8:])
-    elif textx:
-        pcode = str(textx.message)
-    else:
-        return await edit_delete(
-            event,
-            "`No text is given. Either pass text along with cmd or reply to text`",
-        )
-    pcode = deEmojify(pcode)
-    code = quote_plus(pcode)
+    cat = await edit_or_reply(event, "`Processing..`")
+    carbon_url = "https://carbon.now.sh/?l={lang}&code={code}"
+
+    query = event.pattern_match.group(1)
+    replied_msg = await event.get_reply_message()
+    if not query and replied_msg:
+        query = replied_msg.text
+    if query is None:
+        return await edit_delete(cat, query)
+
+    code = quote_plus(deEmojify(query))
     cat = await edit_or_reply(event, "`Carbonizing...\n25%`")
-    url = CARBON.format(code=code, lang=CARBONLANG)
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")
-    chrome_options.binary_location = Config.CHROME_BIN
-    chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_argument("--no-sandbox")
-    chrome_options.add_argument("--disable-gpu")
-    prefs = {"download.default_directory": "./"}
-    chrome_options.add_experimental_option("prefs", prefs)
-    driver = webdriver.Chrome(
-        executable_path=Config.CHROME_DRIVER, options=chrome_options
-    )
+    url = carbon_url.format(code=code, lang=carbon_language)
+    driver, driver_message = chromeDriver.start_driver()
+    if driver is None:
+        return await edit_delete(event, driver_message)
     driver.get(url)
     await edit_or_reply(cat, "`Be Patient...\n50%`")
-    download_path = "./"
-    driver.command_executor._commands["send_command"] = (
-        "POST",
-        "/session/$sessionId/chromium/send_command",
-    )
-    params = {
-        "cmd": "Page.setDownloadBehavior",
-        "params": {"behavior": "allow", "downloadPath": download_path},
-    }
-    driver.execute("send_command", params)
-    driver.find_element("xpath", "//button[contains(text(),'Export')]").click()
+    download_carbon(driver, url)
 
     await edit_or_reply(cat, "`Processing..\n75%`")
 
@@ -95,7 +85,6 @@ async def carbon_api(event):
     )
     os.remove("./carbon.png")
     driver.quit()
-
     await cat.delete()
 
 
@@ -113,46 +102,21 @@ async def carbon_api(event):
 async def kar1_api(event):
     """A Wrapper for carbon.now.sh"""
     cat = await edit_or_reply(event, "🔲🔲🔲🔲🔲")
-    CARBON = "https://carbon.now.sh/?bg=rgba(249%2C237%2C212%2C0)&t=synthwave-84&wt=none&l=application%2Fjson&ds=true&dsyoff=20px&dsblur=0px&wc=true&wa=true&pv=56px&ph=0px&ln=false&fl=1&fm=IBM%20Plex%20Mono&fs=14.5px&lh=153%25&si=false&es=4x&wm=false&code={code}"
-    textx = await event.get_reply_message()
-    pcode = event.text
-    if pcode[6:]:
-        pcode = str(pcode[6:])
-    elif textx:
-        pcode = str(textx.message)
-    else:
-        return await edit_delete(
-            cat, "`No text is given. Either pass text along with cmd or reply to text`"
-        )
-    code = quote_plus(pcode)
-    url = CARBON.format(code=code, lang=CARBONLANG)
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")
-    chrome_options.binary_location = Config.CHROME_BIN
-    chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_argument("--no-sandbox")
-    chrome_options.add_argument("--disable-gpu")
-    prefs = {"download.default_directory": "./"}
-    chrome_options.add_experimental_option("prefs", prefs)
+    carbon_url = "https://carbon.now.sh/?bg=rgba(249%2C237%2C212%2C0)&t=synthwave-84&wt=none&l=application%2Fjson&ds=true&dsyoff=20px&dsblur=0px&wc=true&wa=true&pv=56px&ph=0px&ln=false&fl=1&fm=IBM%20Plex%20Mono&fs=14.5px&lh=153%25&si=false&es=4x&wm=false&code={code}"
+
+    query = event.pattern_match.group(1)
+    replied_msg = await event.get_reply_message()
+    if not query and replied_msg:
+        query = replied_msg.text
+    if query is None:
+        return await edit_delete(cat, query)
+
+    code = quote_plus(query)
     await edit_or_reply(cat, "🔳🔳🔲🔲🔲")
-
-    driver = webdriver.Chrome(
-        executable_path=Config.CHROME_DRIVER, options=chrome_options
-    )
-    driver.get(url)
-    download_path = "./"
-    driver.command_executor._commands["send_command"] = (
-        "POST",
-        "/session/$sessionId/chromium/send_command",
-    )
-    params = {
-        "cmd": "Page.setDownloadBehavior",
-        "params": {"behavior": "allow", "downloadPath": download_path},
-    }
-    driver.execute("send_command", params)
-
-    driver.find_element("xpath", "//button[contains(text(),'Export')]").click()
+    driver, driver_message = chromeDriver.start_driver()
+    if driver is None:
+        return await edit_delete(event, driver_message)
+    download_carbon(driver, carbon_url.format(code=code, lang=carbon_language))
     await asyncio.sleep(1)
     await edit_or_reply(cat, "🔳🔳🔳🔲🔲")
     await asyncio.sleep(1)
@@ -166,8 +130,8 @@ async def kar1_api(event):
         reply_to=event.message.reply_to_msg_id,
     )
     os.remove("./carbon.png")
-
     await cat.delete()
+    driver.quit()
 
 
 @catub.cat_cmd(
@@ -184,44 +148,21 @@ async def kar1_api(event):
 async def kar2_api(event):
     """A Wrapper for carbon.now.sh"""
     cat = await edit_or_reply(event, "📛📛📛📛📛")
-    CARBON = "https://carbon.now.sh/?bg=rgba(239%2C40%2C44%2C1)&t=one-light&wt=none&l=application%2Ftypescript&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=143%25&si=false&es=2x&wm=false&code={code}"
-    textx = await event.get_reply_message()
-    pcode = event.text
-    if pcode[6:]:
-        pcode = str(pcode[6:])
-    elif textx:
-        pcode = str(textx.message)
-    else:
-        return await edit_delete(
-            cat, "`No text is given. Either pass text along with cmd or reply to text`"
-        )
-    code = quote_plus(pcode)
-    url = CARBON.format(code=code, lang=CARBONLANG)
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")
-    chrome_options.binary_location = Config.CHROME_BIN
-    chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_argument("--no-sandbox")
-    chrome_options.add_argument("--disable-gpu")
-    prefs = {"download.default_directory": "./"}
-    chrome_options.add_experimental_option("prefs", prefs)
+    carbon_url = "https://carbon.now.sh/?bg=rgba(239%2C40%2C44%2C1)&t=one-light&wt=none&l=application%2Ftypescript&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=143%25&si=false&es=2x&wm=false&code={code}"
+
+    query = event.pattern_match.group(1)
+    replied_msg = await event.get_reply_message()
+    if not query and replied_msg:
+        query = replied_msg.text
+    if query is None:
+        return await edit_delete(cat, query)
+
+    code = quote_plus(query)
     await edit_or_reply(cat, "🔘🔘📛📛📛")
-    driver = webdriver.Chrome(
-        executable_path=Config.CHROME_DRIVER, options=chrome_options
-    )
-    driver.get(url)
-    download_path = "./"
-    driver.command_executor._commands["send_command"] = (
-        "POST",
-        "/session/$sessionId/chromium/send_command",
-    )
-    params = {
-        "cmd": "Page.setDownloadBehavior",
-        "params": {"behavior": "allow", "downloadPath": download_path},
-    }
-    driver.execute("send_command", params)
-    driver.find_element("xpath", "//button[contains(text(),'Export')]").click()
+    driver, driver_message = chromeDriver.start_driver()
+    if driver is None:
+        return await edit_delete(event, driver_message)
+    download_carbon(driver, carbon_url.format(code=code, lang=carbon_language))
     await asyncio.sleep(1)
     await edit_or_reply(cat, "🔘🔘🔘📛📛")
     await asyncio.sleep(1)
@@ -237,7 +178,7 @@ async def kar2_api(event):
     )
 
     os.remove("./carbon.png")
-
+    driver.quit()
     await cat.delete()
 
 
@@ -255,46 +196,21 @@ async def kar2_api(event):
 async def kar3_api(event):
     """A Wrapper for carbon.now.sh"""
     cat = await edit_or_reply(event, "🎛🎛🎛🎛🎛")
-    CARBON = "https://carbon.now.sh/?bg=rgba(74%2C144%2C226%2C1)&t=material&wt=none&l=auto&ds=false&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Fira%20Code&fs=14px&lh=152%25&si=false&es=2x&wm=false&code={code}"
-    textx = await event.get_reply_message()
-    pcode = event.text
-    if pcode[6:]:
-        pcode = str(pcode[6:])
-    elif textx:
-        pcode = str(textx.message)
-    else:
-        return await edit_delete(
-            cat, "`No text is given. Either pass text along with cmd or reply to text`"
-        )
-    code = quote_plus(pcode)
-    url = CARBON.format(code=code, lang=CARBONLANG)
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")
-    chrome_options.binary_location = Config.CHROME_BIN
-    chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_argument("--no-sandbox")
-    chrome_options.add_argument("--disable-gpu")
-    prefs = {"download.default_directory": "./"}
-    chrome_options.add_experimental_option("prefs", prefs)
+    carbon_url = "https://carbon.now.sh/?bg=rgba(74%2C144%2C226%2C1)&t=material&wt=none&l=auto&ds=false&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Fira%20Code&fs=14px&lh=152%25&si=false&es=2x&wm=false&code={code}"
+
+    query = event.pattern_match.group(1)
+    replied_msg = await event.get_reply_message()
+    if not query and replied_msg:
+        query = replied_msg.text
+    if query is None:
+        return await edit_delete(cat, query)
+
+    code = quote_plus(query)
     await edit_or_reply(cat, "🔵🔵🎛🎛🎛")
-
-    driver = webdriver.Chrome(
-        executable_path=Config.CHROME_DRIVER, options=chrome_options
-    )
-    driver.get(url)
-    download_path = "./"
-    driver.command_executor._commands["send_command"] = (
-        "POST",
-        "/session/$sessionId/chromium/send_command",
-    )
-    params = {
-        "cmd": "Page.setDownloadBehavior",
-        "params": {"behavior": "allow", "downloadPath": download_path},
-    }
-    driver.execute("send_command", params)
-
-    driver.find_element("xpath", "//button[contains(text(),'Export')]").click()
+    driver, driver_message = chromeDriver.start_driver()
+    if driver is None:
+        return await edit_delete(event, driver_message)
+    download_carbon(driver, carbon_url.format(code=code, lang=carbon_language))
     await asyncio.sleep(1)
     await edit_or_reply(cat, "🔵🔵🔵🎛🎛")
     await asyncio.sleep(1)
@@ -310,6 +226,7 @@ async def kar3_api(event):
     )
 
     os.remove("./carbon.png")
+    driver.quit()
     await cat.delete()
 
 
@@ -327,48 +244,24 @@ async def kar3_api(event):
 async def kar4_api(event):
     """A Wrapper for carbon.now.sh"""
     cat = await edit_or_reply(event, "🌚🌚🌚🌚🌚")
-    CARBON = "https://carbon.now.sh/?bg=rgba(29%2C40%2C104%2C1)&t=one-light&wt=none&l=application%2Ftypescript&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=143%25&si=false&es=2x&wm=false&code={code}"
-    textx = await event.get_reply_message()
-    pcode = event.text
-    if pcode[6:]:
-        pcode = str(pcode[6:])
-    elif textx:
-        pcode = str(textx.message)
-    else:
-        return await edit_delete(
-            cat, "`No text is given. Either pass text along with cmd or reply to text`"
-        )
-    code = quote_plus(pcode)
-    url = CARBON.format(code=code, lang=CARBONLANG)
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")
-    chrome_options.binary_location = Config.CHROME_BIN
-    chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_argument("--no-sandbox")
-    chrome_options.add_argument("--disable-gpu")
-    prefs = {"download.default_directory": "./"}
-    chrome_options.add_experimental_option("prefs", prefs)
+    carbon_url = "https://carbon.now.sh/?bg=rgba(29%2C40%2C104%2C1)&t=one-light&wt=none&l=application%2Ftypescript&ds=true&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Hack&fs=14px&lh=143%25&si=false&es=2x&wm=false&code={code}"
+
+    query = event.pattern_match.group(1)
+    replied_msg = await event.get_reply_message()
+    if not query and replied_msg:
+        query = replied_msg.text
+    if query is None:
+        return await edit_delete(cat, query)
+
+    code = quote_plus(query)
     await edit_or_reply(cat, "🌝🌝🌚🌚🌚")
-    driver = webdriver.Chrome(
-        executable_path=Config.CHROME_DRIVER, options=chrome_options
-    )
-    driver.get(url)
-    download_path = "./"
-    driver.command_executor._commands["send_command"] = (
-        "POST",
-        "/session/$sessionId/chromium/send_command",
-    )
-    params = {
-        "cmd": "Page.setDownloadBehavior",
-        "params": {"behavior": "allow", "downloadPath": download_path},
-    }
-    driver.execute("send_command", params)
-    driver.find_element("xpath", "//button[contains(text(),'Export')]").click()
-    await asyncio.sleep(1)
-    await edit_or_reply(cat, "🌝🌝🌝🌚🌚")
+    driver, driver_message = chromeDriver.start_driver()
+    if driver is None:
+        return await edit_delete(event, driver_message)
+    download_carbon(driver, carbon_url.format(code=code, lang=carbon_language))
     await asyncio.sleep(1)
     await edit_or_reply(cat, "🌝🌝🌝🌝🌝")
+    await asyncio.sleep(1)
     file = "./carbon.png"
     await edit_or_reply(cat, "✅Karbon4 Completed, Uploading Karbon✅")
     await event.client.send_file(
@@ -380,6 +273,7 @@ async def kar4_api(event):
     )
 
     os.remove("./carbon.png")
+    driver.quit()
     await cat.delete()
 
 
@@ -396,10 +290,10 @@ async def kar4_api(event):
 )
 async def kargb_api(event):
     """A Wrapper for carbon.now.sh"""
-    RED = random.randint(0, 256)
-    GREEN = random.randint(0, 256)
-    BLUE = random.randint(0, 256)
-    THEME = [
+    red_value = random.randint(0, 256)
+    green_value = random.randint(0, 256)
+    blue_value = random.randint(0, 256)
+    theme_list = [
         "3024-night",
         "a11y-dark",
         "blackboard",
@@ -430,47 +324,32 @@ async def kargb_api(event):
         "yeti",
         "zenburn",
     ]
-    CUNTHE = random.randint(0, len(THEME) - 1)
-    The = THEME[CUNTHE]
+    themes_count = random.randint(0, len(theme_list) - 1)
+    selected_theme = theme_list[themes_count]
     cat = await edit_or_reply(event, "⬜⬜⬜⬜⬜")
-    CARBON = "https://carbon.now.sh/?bg=rgba({R}%2C{G}%2C{B}%2C1)&t={T}&wt=none&l=auto&ds=false&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Fira%20Code&fs=14px&lh=152%25&si=false&es=2x&wm=false&code={code}"
-    textx = await event.get_reply_message()
-    pcode = event.text
-    if pcode[7:]:
-        pcode = str(pcode[7:])
-    elif textx:
-        pcode = str(textx.message)
-    else:
-        return await edit_delete(
-            cat, "`No text is given. Either pass text along with cmd or reply to text`"
-        )
-    code = quote_plus(pcode)
-    url = CARBON.format(code=code, R=RED, G=GREEN, B=BLUE, T=The, lang=CARBONLANG)
-    chrome_options = Options()
-    chrome_options.add_argument("--headless")
-    chrome_options.binary_location = Config.CHROME_BIN
-    chrome_options.add_argument("--window-size=1920x1080")
-    chrome_options.add_argument("--disable-dev-shm-usage")
-    chrome_options.add_argument("--no-sandbox")
-    chrome_options.add_argument("--disable-gpu")
-    prefs = {"download.default_directory": "./"}
-    chrome_options.add_experimental_option("prefs", prefs)
+    carbon_url = "https://carbon.now.sh/?bg=rgba({R}%2C{G}%2C{B}%2C1)&t={T}&wt=none&l=auto&ds=false&dsyoff=20px&dsblur=68px&wc=true&wa=true&pv=56px&ph=56px&ln=false&fl=1&fm=Fira%20Code&fs=14px&lh=152%25&si=false&es=2x&wm=false&code={code}"
+
+    query = event.pattern_match.group(1)
+    replied_msg = await event.get_reply_message()
+    if not query and replied_msg:
+        query = replied_msg.text
+    if query is None:
+        return await edit_delete(cat, query)
+
+    code = quote_plus(query)
+    formatted_url = carbon_url.format(
+        code=code,
+        R=red_value,
+        G=green_value,
+        B=blue_value,
+        T=selected_theme,
+        lang=carbon_language,
+    )
     await edit_or_reply(cat, "⬛⬛⬜⬜⬜")
-    driver = webdriver.Chrome(
-        executable_path=Config.CHROME_DRIVER, options=chrome_options
-    )
-    driver.get(url)
-    download_path = "./"
-    driver.command_executor._commands["send_command"] = (
-        "POST",
-        "/session/$sessionId/chromium/send_command",
-    )
-    params = {
-        "cmd": "Page.setDownloadBehavior",
-        "params": {"behavior": "allow", "downloadPath": download_path},
-    }
-    driver.execute("send_command", params)
-    driver.find_element("xpath", "//button[contains(text(),'Export')]").click()
+    driver, driver_message = chromeDriver.start_driver()
+    if driver is None:
+        return await edit_delete(event, driver_message)
+    download_carbon(driver, formatted_url)
     await asyncio.sleep(1)
     await edit_or_reply(cat, "⬛⬛⬛⬜⬜")
     await asyncio.sleep(1)
@@ -486,4 +365,5 @@ async def kargb_api(event):
     )
 
     os.remove("./carbon.png")
+    driver.quit()
     await cat.delete()

--- a/userbot/plugins/carbon.py
+++ b/userbot/plugins/carbon.py
@@ -58,7 +58,7 @@ async def carbon_api(event):
     if not query and replied_msg:
         query = replied_msg.text
     if query is None:
-        return await edit_delete(cat, query)
+        return await edit_delete(cat, "No text was given")
 
     code = quote_plus(deEmojify(query))
     cat = await edit_or_reply(event, "`Carbonizing...\n25%`")
@@ -109,7 +109,7 @@ async def kar1_api(event):
     if not query and replied_msg:
         query = replied_msg.text
     if query is None:
-        return await edit_delete(cat, query)
+        return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
     await edit_or_reply(cat, "🔳🔳🔲🔲🔲")
@@ -155,7 +155,7 @@ async def kar2_api(event):
     if not query and replied_msg:
         query = replied_msg.text
     if query is None:
-        return await edit_delete(cat, query)
+        return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
     await edit_or_reply(cat, "🔘🔘📛📛📛")
@@ -203,7 +203,7 @@ async def kar3_api(event):
     if not query and replied_msg:
         query = replied_msg.text
     if query is None:
-        return await edit_delete(cat, query)
+        return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
     await edit_or_reply(cat, "🔵🔵🎛🎛🎛")
@@ -251,7 +251,7 @@ async def kar4_api(event):
     if not query and replied_msg:
         query = replied_msg.text
     if query is None:
-        return await edit_delete(cat, query)
+        return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
     await edit_or_reply(cat, "🌝🌝🌚🌚🌚")
@@ -334,7 +334,7 @@ async def kargb_api(event):
     if not query and replied_msg:
         query = replied_msg.text
     if query is None:
-        return await edit_delete(cat, query)
+        return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
     formatted_url = carbon_url.format(


### PR DESCRIPTION
This PR fixes ChromeDriver initialization on selenium 4.10. Avoid getting this error:

`WebDriver.init() got an unexpected keyword argument 'chrome_options'`

Carbon plugin have some duplicate lines removed and some refactoring.

More info about selenium deprecation removals on version 4.10:

https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/#python-1

