### PR TITLE
Fix carbons when no message and no reply provided

### DIFF
--- a/userbot/plugins/carbon.py
+++ b/userbot/plugins/carbon.py
@@ -57,7 +57,7 @@ async def carbon_api(event):
     replied_msg = await event.get_reply_message()
     if not query and replied_msg:
         query = replied_msg.message
-    if query is None:
+    if not query:
         return await edit_delete(cat, "No text was given")
 
     code = quote_plus(deEmojify(query))
@@ -108,7 +108,7 @@ async def kar1_api(event):
     replied_msg = await event.get_reply_message()
     if not query and replied_msg:
         query = replied_msg.message
-    if query is None:
+    if not query:
         return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
@@ -154,7 +154,7 @@ async def kar2_api(event):
     replied_msg = await event.get_reply_message()
     if not query and replied_msg:
         query = replied_msg.message
-    if query is None:
+    if not query:
         return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
@@ -202,7 +202,7 @@ async def kar3_api(event):
     replied_msg = await event.get_reply_message()
     if not query and replied_msg:
         query = replied_msg.message
-    if query is None:
+    if not query:
         return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
@@ -250,7 +250,7 @@ async def kar4_api(event):
     replied_msg = await event.get_reply_message()
     if not query and replied_msg:
         query = replied_msg.message
-    if query is None:
+    if not query:
         return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)
@@ -333,7 +333,7 @@ async def kargb_api(event):
     replied_msg = await event.get_reply_message()
     if not query and replied_msg:
         query = replied_msg.message
-    if query is None:
+    if not query:
         return await edit_delete(cat, "No text was given")
 
     code = quote_plus(query)


### PR DESCRIPTION
Yet another mistake i made. Carbons with no parameter or replied message returned some weird things.

![imagen](https://github.com/TgCatUB/catuserbot/assets/1206625/e9c58108-43d1-4371-a71b-e4c9c80ce5c1)

This PR solves that,