### PR TITLE
fix: don't save already formatted PM_TEXT every time is calculated in pmpermit plugin

### DIFF
--- a/userbot/plugins/pmpermit.py
+++ b/userbot/plugins/pmpermit.py
@@ -148,7 +148,6 @@ Choose an option from below to specify the reason of your message and wait for m
 You have {warns}/{totalwarns} warns until you get blocked by the CatUserbot.
 
 Don't spam my inbox. say reason and wait until my response.__"""
-    addgvar("PM_TEXT", USER_BOT_NO_WARN)
     PM_WARNS[str(chat.id)] += 1
     try:
         if gvarstatus("pmmenu") is None:


### PR DESCRIPTION
remove one line to avoid a weird behaviour in pmpermit plugin where PM_TEXT template is replaced with already formatted text no matter if it's a custom template or default one.